### PR TITLE
Adding Area for Polylines with Arcs

### DIFF
--- a/src/DxfLibrary/GeoMath/BasicGeometry.cs
+++ b/src/DxfLibrary/GeoMath/BasicGeometry.cs
@@ -13,6 +13,9 @@ namespace DxfLibrary.GeoMath
     /// </summary>
     public static class BasicGeometry
     {
+        /// <summary>
+        /// The Tolerance for floating point numbers in this library.
+        /// </summary>
         public static double Tolerance = 1E-10;
 
         /// <summary>

--- a/src/DxfLibrary/GeoMath/BasicGeometry.cs
+++ b/src/DxfLibrary/GeoMath/BasicGeometry.cs
@@ -52,7 +52,7 @@ namespace DxfLibrary.GeoMath
         /// <param name="radius">The radius of the circle</param>
         /// <param name="angle">The angle that the segment occupies in Radians</param>
         /// <returns>The Area of the segment</returns>
-        public static double CircleSegmentArea(double radius, double angle) => Math.Pow(radius, 2) * (angle - Math.Sin(angle));
+        public static double CircleSegmentArea(double radius, double angle) => Math.Pow(radius, 2) * 0.5 * (angle - Math.Sin(angle));
 
         #region Unit Conversion
 

--- a/src/DxfLibrary/GeoMath/Vector.cs
+++ b/src/DxfLibrary/GeoMath/Vector.cs
@@ -96,6 +96,23 @@ namespace DxfLibrary.GeoMath
 
         #endregion
 
+        #region Overrides
+
+        /// <summary>
+        /// Overloaded operator + for the vector type
+        /// </summary>
+        /// <param name="a">The first vector</param>
+        /// <param name="b">The second vector</param>
+        /// <returns>Returns a new vector which is the addition of the two vectors</returns>
+        public static Vector operator +(Vector a, Vector b)
+        {
+            return new Vector(new GeoPoint(a.Origin.X + b.Origin.X, a.Origin.Y + b.Origin.Y, a.Origin.Z + b.Origin.Z),
+                new GeoPoint(a.Destination.X + b.Destination.X,
+                a.Destination.Y + b.Destination.Y, a.Destination.Z + b.Destination.Z));
+        }
+
+        #endregion
+
         #region UnitVectors
 
         /// <summary>

--- a/src/DxfLibrary/GeoMath/Vector.cs
+++ b/src/DxfLibrary/GeoMath/Vector.cs
@@ -140,6 +140,36 @@ namespace DxfLibrary.GeoMath
                 a.Destination.Y + b.Destination.Y, a.Destination.Z + b.Destination.Z));
         }
 
+        /// <summary>
+        /// Equals override for the vector type
+        /// </summary>
+        /// <param name="obj">The object that you are comparing</param>
+        /// <returns>Returns true if the vector is equal to another vector</returns>
+        public override bool Equals(object obj)
+        {
+            var vector = obj as Vector;
+
+            if (vector == null)
+                return false;
+
+            return Origin.Equals(vector.Origin) && 
+                Destination.Equals(vector.Destination);
+        }
+
+        /// <summary>
+        /// Override for the GetHashCode Type
+        /// </summary>
+        /// <returns>Returns: an int which is the hash code for the vector</returns>
+        public override int GetHashCode()
+        {
+            int hash = 983251653;
+
+            hash = (hash * 817504243) + Origin.GetHashCode();
+            hash = (hash * 817504243) + Destination.GetHashCode();
+
+            return hash;
+        }
+
         #endregion
 
         #region UnitVectors

--- a/src/DxfLibrary/GeoMath/Vector.cs
+++ b/src/DxfLibrary/GeoMath/Vector.cs
@@ -101,6 +101,18 @@ namespace DxfLibrary.GeoMath
         /// <returns>Returns: The result of the dot product</returns>
         public double Dot(Vector other) => X * other.X + Y * other.Y + Z * other.Z;
 
+        /// <summary>
+        /// The Cross Product of this vector and another vector.
+        /// Note that this returns a new vector where this origin is the same
+        /// as this vector.
+        /// </summary>
+        /// <param name="v2">The other vector that is being crossed</param>
+        /// <returns>Returns: A new vector</returns>
+        public Vector Cross(Vector v2) => new Vector(Origin, 
+            new GeoPoint(Origin.X + Y*v2.Z - v2.Y*Z,
+            Origin.Y + v2.X*Z - X*v2.Z,
+            Origin.Z + (X*v2.Y - v2.X*Y)));
+
         #endregion
 
         #region Overrides

--- a/src/DxfLibrary/GeoMath/Vector.cs
+++ b/src/DxfLibrary/GeoMath/Vector.cs
@@ -30,6 +30,16 @@ namespace DxfLibrary.GeoMath
             Destination = destination;
         }
 
+        /// <summary>
+        /// Constructor that creates a vector with its tail at the origin
+        /// and the destination given by a <see cref="GeoPoint">.
+        /// </summary>
+        /// <param name="destination">The GeoPoint for the destination</param>
+        public Vector(GeoPoint destination) : this(new GeoPoint(0,0), destination)
+        {
+
+        }
+
         #endregion
 
         #region Public Properties

--- a/src/DxfLibrary/GeoMath/Vector.cs
+++ b/src/DxfLibrary/GeoMath/Vector.cs
@@ -94,6 +94,13 @@ namespace DxfLibrary.GeoMath
              new GeoPoint(origin.X + X, origin.Y + Y, origin.Z + Z));
         }
 
+        /// <summary>
+        /// Dot product of the vector and another vector
+        /// </summary>
+        /// <param name="other">The other vector to dot with</param>
+        /// <returns>Returns: The result of the dot product</returns>
+        public double Dot(Vector other) => X * other.X + Y * other.Y + Z * other.Z;
+
         #endregion
 
         #region Overrides

--- a/src/DxfLibrary/Geometry/Bulge.cs
+++ b/src/DxfLibrary/Geometry/Bulge.cs
@@ -41,7 +41,7 @@ namespace DxfLibrary.Geometry
         /// <summary>
         /// The Angle of the Bulge in Degrees
         /// </summary>
-        public double AngleDeg => Rad2Deg(Angle);
+        public double AngleDeg => BasicGeometry.Rad2Deg(Angle);
 
         /// <summary>
         /// Distance from the Chord line to the highest point of the arc,
@@ -61,12 +61,5 @@ namespace DxfLibrary.Geometry
         /// <returns>The Radius of the Arc</returns>
         public double Radius(GeoPoint p0, GeoPoint p1)
             => BasicGeometry.Distance(p0, p1) * 0.5 * (Math.Pow(Value, 2) + 1) / (2 * Value);
-
-        /// <summary>
-        /// Converter for rads to degs
-        /// </summary>
-        /// <param name="val">Val in radians</param>
-        /// <returns>The value in degrees</returns>
-        private double Rad2Deg(double val) => val * (180 / Math.PI);
     }
 }

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -175,7 +175,7 @@ namespace DxfLibrary.Geometry
 
             // If the bulge value is not equal to 0 then return the 
             // Area of the circle segment
-            return BasicGeometry.CircleSegmentArea(Bulge.Radius(Point0, Point1), Bulge.Angle);
+            return Math.Abs(BasicGeometry.CircleSegmentArea(Bulge.Radius(Point0, Point1), Bulge.Angle));
         }
 
         #endregion

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -145,7 +145,12 @@ namespace DxfLibrary.Geometry
         /// <summary>
         /// Calculate the length of the Segment.
         /// </summary>
-        /// <returns>The length of the line</returns>
+        /// <remarks>
+        /// If the bulge value is 0: Returns the length of the line segment
+        /// 
+        /// If the bulge value is not 0: Returns the arc length of the arc segment
+        /// </remarks>
+        /// <returns>The length of the segment</returns>
         private double CalcLength()
         {
             // If the line has no bulge then calculate the straight length

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -123,7 +123,7 @@ namespace DxfLibrary.Geometry
         /// <summary>
         /// Override of the ToString Method
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Returns: The Lines points and coordinates</returns>
         public override string ToString()
         {
             return $"P0({Point0.X}, {Point0.Y}, {Point0.Z}), P1({Point1.X}, {Point1.Y}, {Point1.Z})";

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -70,6 +70,12 @@ namespace DxfLibrary.Geometry
         public Bulge Bulge {get;}
 
         /// <summary>
+        /// Returns True if the line has a bulge, and false
+        /// if the file does not have a bulge
+        /// </summary>
+        public bool HasBulge => Bulge.Value == 0;
+
+        /// <summary>
         /// The Length of the Line.
         /// </summary>
         /// <remarks>

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -132,7 +132,10 @@ namespace DxfLibrary.Geometry
         /// <summary>
         /// Convert this entity to a vector
         /// </summary>
-        /// <returns>A new vector</returns>
+        /// <returns>
+        /// Returns: A new vector that has the origin and destination
+        /// the same as this lines point 0 and point 1
+        /// </returns>
         public Vector ToVector() => new Vector(Point0, Point1);
 
         #endregion

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -73,7 +73,7 @@ namespace DxfLibrary.Geometry
         /// Returns True if the line has a bulge, and false
         /// if the file does not have a bulge
         /// </summary>
-        public bool HasBulge => Bulge.Value == 0;
+        public bool HasBulge => BasicGeometry.DoubleCompare(Bulge.Value, 0);
 
         /// <summary>
         /// The Length of the Line.

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -108,8 +108,13 @@ namespace DxfLibrary.Geometry
         /// If the bulge is zero then the angle will return 
         /// positive infinity
         /// </summary>
+        /// <remarks>
+        /// If there is no arc then the segment is a line and
+        /// will then have an angle of PI (180 degrees). This angle will be returned 
+        /// in radians.
+        /// </remarks>
         public double Angle
-            => Bulge.Value != 0 ? Bulge.Angle : double.PositiveInfinity;
+            => Bulge.Value != 0 ? Bulge.Angle : Math.PI;
 
         #endregion
 

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -73,7 +73,7 @@ namespace DxfLibrary.Geometry
         /// Returns True if the line has a bulge, and false
         /// if the file does not have a bulge
         /// </summary>
-        public bool HasBulge => BasicGeometry.DoubleCompare(Bulge.Value, 0);
+        public bool HasBulge => !(BasicGeometry.DoubleCompare(Bulge.Value, 0));
 
         /// <summary>
         /// The Length of the Line.

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -178,8 +178,6 @@ namespace DxfLibrary.Geometry
             return BasicGeometry.CircleSegmentArea(Bulge.Radius(Point0, Point1), Bulge.Angle);
         }
 
-
-
         #endregion
     }
 }

--- a/src/DxfLibrary/Geometry/GeoLine.cs
+++ b/src/DxfLibrary/Geometry/GeoLine.cs
@@ -91,7 +91,8 @@ namespace DxfLibrary.Geometry
         /// <summary>
         /// Area of the Segment. The Area of the segment
         /// Is the area of a trapizoid that is bounded by the two points of the
-        /// line.
+        /// line. Note that if the segment is an arc then the area is the area
+        /// bounded by that arc.
         /// </summary>
         public double Area => CalcArea();
 

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -37,8 +37,12 @@ namespace DxfLibrary.Geometry
         {
             // If the numbers do not match then throw an error
             if (x.Count != y.Count || x.Count != bulges.Count)
-                throw new IndexOutOfRangeException();
+                throw new IndexOutOfRangeException("All coordinates must be the same size");
             
+            // If there are less than 2 points then the polyline cannot be defined
+            if (x.Count < 2)
+                throw new ArgumentException("Need more than two points to define a polyline")
+
             _lines = new List<GeoLine>();
 
             // Iterate through and create new lines

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -66,6 +66,12 @@ namespace DxfLibrary.Geometry
                 var bulge = new Bulge(bulges.Last());
                 _lines.Add(new GeoLine(point0, point1, bulge));
             }
+
+            // Determine the draw direction using the first and second
+            // line by converting them to vectors and crossing them.
+            if (_lines.Count > 1)
+                DrawDirection = _lines[0].ToVector()
+                    .Cross( _lines[1].ToVector() ).Z;
         }
 
         /// <summary>
@@ -91,6 +97,13 @@ namespace DxfLibrary.Geometry
         /// Get the total area of all the lines
         /// </summary>
         public double Area => CalcArea();
+
+        /// <summary>
+        /// The Draw direction of the polyline.
+        /// If the value is >0 then the draw direction is counterclockwise
+        /// If the value is less than 0 then the direction is clockwise
+        /// </summary>
+        public double DrawDirection {get;}
 
         #endregion
 

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -144,7 +144,11 @@ namespace DxfLibrary.Geometry
                 }
 
                 // First add the area of the Trapizoid
-                sum += new GeoLine(segment.Point0, segment.Point1).Length;
+                if (DrawDirection > 0)
+                    sum += (new GeoLine(segment.Point0, segment.Point1).Area) * -1.0;
+
+                else if (DrawDirection < 0)
+                    sum += new GeoLine(segment.Point0, segment.Point1).Area;
 
                 // This value will determine if we are to add or subtract the segment area
                 var segmentAreaSwtich = DrawDirection * segment.Bulge.Value;

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using DxfLibrary.GeoMath;
+
 namespace DxfLibrary.Geometry
 {
     public class GeoPolyline : GeoBase, IGeoLength, IGeoArea
@@ -71,5 +73,23 @@ namespace DxfLibrary.Geometry
         /// Get the total area of all the lines
         /// </summary>
         public double Area => _lines.Select(l => l.Area).Sum();
+
+        private double CalcArea()
+        {
+            double sum = 0.0;
+            for (var index = 0; index < _lines.Count; ++index)
+            {
+                var segment = _lines[index];
+
+                // If the segment does not have a bulge just add its area
+                if (BasicGeometry.DoubleCompare(segment.Bulge.Value, 0))
+                {
+                    sum += segment.Area;
+                    continue;
+                }
+
+            }
+            return sum;
+        }
     }
 }

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -161,7 +161,7 @@ namespace DxfLibrary.Geometry
                 
             }
 
-            return sum;
+            return Math.Abs(sum);
         }
 
 

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -146,7 +146,18 @@ namespace DxfLibrary.Geometry
                     continue;
                 }
 
-                // TODO: Add section of code that adds areas if there is a bulge
+                // First add the area of the Trapizoid
+                sum += new GeoLine(segment.Point0, segment.Point1).Length;
+
+                // This value will determine if we are to add or subtract the segment area
+                var segmentAreaSwtich = DrawDirection * segment.Bulge.Value;
+
+                if (segmentAreaSwtich > 0)
+                    sum += segment.Area;
+
+                else if (segmentAreaSwtich < 0)
+                    sum -= segment.Area;
+                
             }
 
             return sum;

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -90,19 +90,6 @@ namespace DxfLibrary.Geometry
         /// <summary>
         /// Get the total area of all the lines
         /// </summary>
-<<<<<<< HEAD
-        public double Area => _lines.Select(l => l.Area).Sum();
-
-        private double CalcArea()
-        {
-            double sum = 0.0;
-            for (var index = 0; index < _lines.Count; ++index)
-            {
-                var segment = _lines[index];
-
-                // If the segment does not have a bulge just add its area
-                if (BasicGeometry.DoubleCompare(segment.Bulge.Value, 0))
-=======
         public double Area => CalcArea();
 
         #endregion
@@ -141,17 +128,11 @@ namespace DxfLibrary.Geometry
                 // If the segment does not have a bulge then
                 // Add the area from the object to the sum
                 if (!segment.HasBulge)
->>>>>>> 38d0565e660ecfc0fda18d48f887cd99e3e2a57d
                 {
                     sum += segment.Area;
                     continue;
                 }
 
-<<<<<<< HEAD
-            }
-            return sum;
-        }
-=======
                 // TODO: Add section of code that adds areas if there is a bulge
             }
 
@@ -161,6 +142,5 @@ namespace DxfLibrary.Geometry
 
 
         #endregion
->>>>>>> 38d0565e660ecfc0fda18d48f887cd99e3e2a57d
     }
 }

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -133,11 +133,8 @@ namespace DxfLibrary.Geometry
 
             // Need to iterate through the lines to caluclate the 
             // Total area
-            for (int index = 0; index < _lines.Count; ++index)
+            foreach(var segment in  _lines)
             {
-                // The current segment
-                var segment = _lines[index];
-
                 // If the segment does not have a bulge then
                 // Add the area from the object to the sum
                 if (!segment.HasBulge)

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -10,10 +10,16 @@ namespace DxfLibrary.Geometry
 {
     public class GeoPolyline : GeoBase, IGeoLength, IGeoArea
     {
+        #region Private Members
+
         /// <summary>
         /// Private backing field for lines
         /// </summary>
         private List<GeoLine> _lines;
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Constructor for the GeoPolyline that takes in Lists of
@@ -62,6 +68,10 @@ namespace DxfLibrary.Geometry
         {
         }
 
+        #endregion
+
+        #region Public Properties
+
         /// <summary>
         /// Get the total length of all the lines
         /// </summary>
@@ -70,6 +80,37 @@ namespace DxfLibrary.Geometry
         /// <summary>
         /// Get the total area of all the lines
         /// </summary>
-        public double Area => _lines.Select(l => l.Area).Sum();
+        public double Area => CalcArea();
+
+        #endregion
+
+        #region Private Methods
+
+        private double CalcArea()
+        {
+            double sum = 0.0d;
+
+            // Need to iterate through the lines to caluclate the 
+            // Total area
+            for (int index = 0; index < _lines.Count; ++index)
+            {
+                // The current segment
+                var segment = _lines[index];
+
+                // If the segment does not have a bulge then
+                // Add the area from the object to the sum
+                if (!segment.HasBulge)
+                {
+                    sum += segment.Area;
+                    continue;
+                }
+
+                // TODO: Add section of code that adds areas if there is a bulge
+            }
+
+            return sum;
+        }
+
+        #endregion
     }
 }

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -3,12 +3,16 @@
 // Created on: 2019-01-13
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace DxfLibrary.Geometry
 {
-    public class GeoPolyline : GeoBase, IGeoLength, IGeoArea
+    /// <summary>
+    /// Class that represents a collection of Geolines
+    /// </summary>
+    public class GeoPolyline : GeoBase, IGeoLength, IGeoArea, IEnumerable<GeoLine>
     {
         #region Private Members
 
@@ -84,6 +88,24 @@ namespace DxfLibrary.Geometry
 
         #endregion
 
+        #region Public Methods
+        
+        /// <summary>
+        /// Get the enumerator for the lines in the polyline
+        /// </summary>
+        /// <returns>Returns the Enumberator for the lines in the polyline</returns>
+        public IEnumerator<GeoLine> GetEnumerator()
+        {
+            return _lines.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Gets the enumerator for the polyline class
+        /// </summary>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        
+        #endregion
+
         #region Private Methods
 
         private double CalcArea()
@@ -110,6 +132,8 @@ namespace DxfLibrary.Geometry
 
             return sum;
         }
+
+
 
         #endregion
     }

--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -41,7 +41,7 @@ namespace DxfLibrary.Geometry
             
             // If there are less than 2 points then the polyline cannot be defined
             if (x.Count < 2)
-                throw new ArgumentException("Need more than two points to define a polyline")
+                throw new ArgumentException("Need more than two points to define a polyline");
 
             _lines = new List<GeoLine>();
 

--- a/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
+++ b/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
@@ -82,7 +82,7 @@ namespace DxfLibrary.Tests.GeoMath
         /// </summary>
         [Theory]
         [ClassData(typeof(AdditionTestData))]
-        public static void AdditionTest(Vector b, Vector expected)
+        public void AdditionTest(Vector b, Vector expected)
         {
             var a = new Vector(new GeoPoint(0,0), new GeoPoint(1,0));
             var test = a + b;
@@ -94,7 +94,7 @@ namespace DxfLibrary.Tests.GeoMath
         /// </summary>
         [Theory]
         [ClassData(typeof(RotationTestData))]
-        public static void RotationTest(double angle, GeoPoint finalDestination)
+        public void RotationTest(double angle, GeoPoint finalDestination)
         {
             var testVec = Vector.UnitVectorX;
             testVec.RotateZ(BasicGeometry.Deg2Rad(angle));
@@ -105,7 +105,7 @@ namespace DxfLibrary.Tests.GeoMath
         /// Trivial Test for the dot product of two vectors
         /// </summary>
         [Fact]
-        public static void DotProdTest()
+        public void DotProdTest()
         {
             // Two Random vectors
             var vec1 = new Vector(new GeoPoint(2,3), new GeoPoint(5,2));
@@ -119,7 +119,7 @@ namespace DxfLibrary.Tests.GeoMath
         }
 
         [Fact]
-        public static void CrossProdTest()
+        public void CrossProdTest()
         {
             var vec1 = new Vector(new GeoPoint(2, 3, 4));
             var vec2 = new Vector(new GeoPoint(4, 5, 6));

--- a/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
+++ b/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
@@ -77,6 +77,9 @@ namespace DxfLibrary.Tests.GeoMath
 
         #region Tests
 
+        /// <summary>
+        /// Test for the addition of two vectors
+        /// </summary>
         [Theory]
         [ClassData(typeof(AdditionTestData))]
         public static void AdditionTest(Vector b, Vector expected)
@@ -86,6 +89,9 @@ namespace DxfLibrary.Tests.GeoMath
             Assert.Equal(expected.Length, test.Length);
         }
 
+        /// <summary>
+        /// Test for the Rotation of a vector
+        /// </summary>
         [Theory]
         [ClassData(typeof(RotationTestData))]
         public static void RotationTest(double angle, GeoPoint finalDestination)
@@ -94,6 +100,25 @@ namespace DxfLibrary.Tests.GeoMath
             testVec.RotateZ(BasicGeometry.Deg2Rad(angle));
             Assert.Equal(finalDestination, testVec.Destination);
         }
+
+        /// <summary>
+        /// Trivial Test for the dot product of two vectors
+        /// </summary>
+        [Fact]
+        public static void DotProdTest()
+        {
+            // Two Random vectors
+            var vec1 = new Vector(new GeoPoint(2,3), new GeoPoint(5,2));
+            var vec2 = new Vector(new GeoPoint(5,7), new GeoPoint(9,1));
+
+            // Dot product
+            var result = vec1.Dot(vec2);
+            var expected = 18.0;
+
+            Assert.Equal(expected, result);
+        }
+
+        
 
         #endregion
 

--- a/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
+++ b/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
@@ -27,21 +27,37 @@ namespace DxfLibrary.Tests.GeoMath
         {
         }
 
-        #region Tests
-
+        #region TestData
+        
+        /// <summary>
+        /// Data for the rotation tests
+        /// </summary>
         class RotationTestData : IEnumerable<object[]>
         {
+            // Rotation data
             public IEnumerator<object[]> GetEnumerator()
             {
+                // 90 degrees counterclockwise rotation
                 yield return new object[]
                 {
                     90,
                     new GeoPoint(0,1)
                 };
+
+                // 90 degrees clockwise rotation
+                yield return new object[]
+                {
+                    -90,
+                    new GeoPoint(0, -1)
+                };
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+        
+        #endregion
+
+        #region Tests
 
         [Theory]
         [ClassData(typeof(RotationTestData))]

--- a/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
+++ b/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
@@ -118,7 +118,17 @@ namespace DxfLibrary.Tests.GeoMath
             Assert.Equal(expected, result);
         }
 
-        
+        [Fact]
+        public static void CrossProdTest()
+        {
+            var vec1 = new Vector(new GeoPoint(2, 3, 4));
+            var vec2 = new Vector(new GeoPoint(4, 5, 6));
+
+            var test = vec1.Cross(vec2);
+
+            var expected = new Vector(new GeoPoint(-2, 4, -2));
+            Assert.Equal(expected, test);
+        }
 
         #endregion
 

--- a/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
+++ b/tests/DxfLibrary.Tests/GeoMath/VectorTests.cs
@@ -28,7 +28,25 @@ namespace DxfLibrary.Tests.GeoMath
         }
 
         #region TestData
-        
+
+        // Addintion test Data
+        class AdditionTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[]
+                {
+                    new Vector(new GeoPoint(0,0), new GeoPoint(0,1)),
+                    new Vector(new GeoPoint(0,0), new GeoPoint(1,1))
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
         /// <summary>
         /// Data for the rotation tests
         /// </summary>
@@ -58,6 +76,15 @@ namespace DxfLibrary.Tests.GeoMath
         #endregion
 
         #region Tests
+
+        [Theory]
+        [ClassData(typeof(AdditionTestData))]
+        public static void AdditionTest(Vector b, Vector expected)
+        {
+            var a = new Vector(new GeoPoint(0,0), new GeoPoint(1,0));
+            var test = a + b;
+            Assert.Equal(expected.Length, test.Length);
+        }
 
         [Theory]
         [ClassData(typeof(RotationTestData))]

--- a/tests/DxfLibrary.Tests/Geometry/GeoPolylineTests.cs
+++ b/tests/DxfLibrary.Tests/Geometry/GeoPolylineTests.cs
@@ -3,6 +3,7 @@
 // 2019-01-27
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using DxfLibrary.Geometry;
 using Xunit;
@@ -22,6 +23,51 @@ namespace DxfLibrary.Tests.Geometry
         {
         }
 
+        #region TestData
+
+        /// <summary>
+        /// Class for holding the data for testing areas
+        /// </summary>
+        class AreaTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                // Type: Arc
+                // Draw Direction: CCW
+                // Bulge: +ve
+                yield return new object[]
+                {
+                    new GeoPolyline
+                    (
+                        new List<double>{ 0, 5, 5, 0 }, 
+                        new List<double>{ 0, 0, 2.5, 2.5 }, 
+                        new List<double>{ 0, 0, 1, 0}, 
+                        true
+                    ),
+                    22.3175
+                };
+
+                // Type: Arc
+                // Draw Direction: CW
+                // Bulge: -ve
+                yield return new object[]
+                {
+                    new GeoPolyline
+                    (
+                        new List<double>{ 0, 0, 5, 5 },
+                        new List<double>{ 0, 2.5, 2.5, 0 },
+                        new List<double>{ 0, -1.0, 0, 0 },
+                        true
+                    ),
+                    22.3175
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        #endregion
+
         #region Tests
 
         [Fact]
@@ -40,6 +86,11 @@ namespace DxfLibrary.Tests.Geometry
             Assert.Equal(3, count);
         }
 
+        [Theory]
+        [ClassData(typeof(AreaTestData))]
+        public void AreaTests(GeoPolyline polyline, double expectedArea) => Assert.Equal(expectedArea, polyline.Area, 4);
+
         #endregion
+
     }
 }

--- a/tests/DxfLibrary.Tests/Geometry/GeoPolylineTests.cs
+++ b/tests/DxfLibrary.Tests/Geometry/GeoPolylineTests.cs
@@ -61,6 +61,65 @@ namespace DxfLibrary.Tests.Geometry
                     ),
                     22.3175
                 };
+            
+                // Type: Arc
+                // Draw Direction: CCW
+                // Bulge: -ve
+                yield return new object[]
+                {
+                    new GeoPolyline
+                    (
+                        new List<double>{ 0, 5, 5, 0 },
+                        new List<double>{ 0, 0, 2.5, 2.5 },
+                        new List<double>{ 0, 0, -0.6, 0 },
+                        true
+                    ),
+                    7.1566
+                };
+
+                // Type: Arc
+                // Draw Direction: CW
+                // Bulge: +ve
+                yield return new object[]
+                {
+                    new GeoPolyline
+                    (
+                        new List<double>{ 0, 0, 5, 5 },
+                        new List<double>{ 0, 2.5, 2.5, 0 },
+                        new List<double>{ 0, 0.6, 0, 0 },
+                        true                      
+                    ),
+                    7.1566
+                };
+
+                // Type: Line
+                // Draw Direction: CCW
+                yield return new object[]
+                {
+                    new GeoPolyline
+                    (
+                        new List<double>{ 0, 5, 5, 0 },
+                        new List<double>{ 0, 0, 2.5, 2.5 },
+                        new List<double>{ 0, 0, 0, 0 },
+                        true
+                    ),
+                    12.5
+                };
+
+                // Type Line
+                // Draw Direction: CW
+                yield return new object[]
+                {
+                    new GeoPolyline
+                    (
+                        new List<double>{ 0, 0, 5, 5 },
+                        new List<double>{ 0, 2.5, 2.5, 0 },
+                        new List<double>{ 0, 0, 0, 0 },
+                        true                      
+                    ),
+                    12.5
+                };
+
             }
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/tests/DxfLibrary.Tests/Geometry/GeoPolylineTests.cs
+++ b/tests/DxfLibrary.Tests/Geometry/GeoPolylineTests.cs
@@ -1,0 +1,45 @@
+// GeoPolylineTests.cs
+// By: Adam Renaud
+// 2019-01-27
+
+using System;
+using System.Collections.Generic;
+using DxfLibrary.Geometry;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DxfLibrary.Tests.Geometry
+{
+    /// <summary>
+    /// Class for testing the Geopolyline
+    /// </summary>
+    public class GeoPolylineTests : TestBase
+    {
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        public GeoPolylineTests(ITestOutputHelper logger) : base(logger)
+        {
+        }
+
+        #region Tests
+
+        [Fact]
+        public void EnumerableTest()
+        {
+            // A random polyline with three lines
+            List<double> x = new List<double>() {0,2,5};
+            List<double> y = new List<double>() {2,3,2};
+            var polyline = new GeoPolyline(x, y, true);
+
+            var count = 0;
+            // Just test to see that we hit this three times
+            foreach(var line in polyline)
+                count++;
+
+            Assert.Equal(3, count);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Added the ability to calculate the area of an LWPOLYLINE that has arcs. This includes tests and implementation code.