### PR TITLE
Fix Area calculation

### DIFF
--- a/src/DxfLibrary/Geometry/GeoPolyline.cs
+++ b/src/DxfLibrary/Geometry/GeoPolyline.cs
@@ -144,19 +144,12 @@ namespace DxfLibrary.Geometry
                 }
 
                 // First add the area of the Trapizoid
-                if (DrawDirection > 0)
-                    sum += (new GeoLine(segment.Point0, segment.Point1).Area) * -1.0;
+                sum += new GeoLine(segment.Point0, segment.Point1).Area;
 
-                else if (DrawDirection < 0)
-                    sum += new GeoLine(segment.Point0, segment.Point1).Area;
-
-                // This value will determine if we are to add or subtract the segment area
-                var segmentAreaSwtich = DrawDirection * segment.Bulge.Value;
-
-                if (segmentAreaSwtich > 0)
+                if (segment.Bulge.Value < 0)
                     sum += segment.Area;
 
-                else if (segmentAreaSwtich < 0)
+                else if (segment.Bulge.Value > 0)
                     sum -= segment.Area;
                 
             }


### PR DESCRIPTION
If you rotate the polyline the calculated area results wrong.

This should solve the error.
I can provide some test files with CCW and CW polylines.